### PR TITLE
Fixed filter on name and scans fails (#12)

### DIFF
--- a/web/magmaweb/job.py
+++ b/web/magmaweb/job.py
@@ -792,7 +792,7 @@ class Job(object):
                 fq = fq.join(Peak, and_(Fragment.scanid==Peak.scanid, Fragment.mz==Peak.mz))
                 fq = self.extjsgridfilter(fq, Peak.assigned_metid, filter)
             else:
-                fq = fq.join(Metabolite)
+                fq = fq.join(Metabolite, Fragment.metabolite)
                 fq = self.extjsgridfilter(
                                           fq,
                                           Metabolite.__dict__[filter['field']], #@UndefinedVariable

--- a/web/magmaweb/tests/test_job.py
+++ b/web/magmaweb/tests/test_job.py
@@ -997,6 +997,10 @@ class JobScansWithMetabolitesTestCase(unittest.TestCase):
         response = self.job.scansWithMetabolites(filters=[{"type":"boolean","value": True,"field":"assigned"}])
         self.assertEqual(response, [])
 
+    def test_filteredon_nrscansgt_and_molformula(self):
+        response = self.job.scansWithMetabolites(filters=[{"type":"numeric","comparison":"lt","value":2,"field":"nhits"}, {"type":"string","value":"C6","field":"molformula"}])
+        self.assertEqual(len(response), 1)
+
 class JobMSpectraTestCase(unittest.TestCase):
     def setUp(self):
         import uuid


### PR DESCRIPTION
The metabolites table was joined multiple times, giving a 'ambiguous column name' error.

Using a explicit target during join prevents metabolites to be joined more then once.
