### PR TITLE
Make fragments with even mslevel a different background color as

### DIFF
--- a/web/magmaweb/static/app/view/fragment/Tree.js
+++ b/web/magmaweb/static/app/view/fragment/Tree.js
@@ -18,7 +18,13 @@ Ext.define('Esc.magmaweb.view.fragment.Tree', {
   multiSelect: false,
   rootVisible: false,
   singleExpand: true,
-  useArrows: true,
+  rowLines: true,
+  viewConfig: {
+	getRowClass: function(record) {
+		// Make transition between mslevel visible by giving even/odd mslevel different bg color
+    	return record.get("mslevel") % 2 === 0 ? this.altRowCls : "";
+	}
+  },
   tools: [{
      type: 'save',
      disabled: true,


### PR DESCRIPTION
fragments with odd mslevel.
Switch back to default arrows so the number of vertical lines in front
of the icon also gives an indication of depth.
Turn on rowLines to easier see different rows.

This fixes #3
