### PR TITLE
Added silent parameter to selectScan() to prevent unSelectScan event fro...

### DIFF
--- a/web/magmaweb/static/app/controller/Scans.js
+++ b/web/magmaweb/static/app/controller/Scans.js
@@ -203,7 +203,7 @@ Ext.define('Esc.magmaweb.controller.Scans', {
       function(b,v) {
         if (b != 'cancel' && v) {
          v = v*1;
-         me.selectScan(v);
+         me.selectScan(v, true);
         }
       }
     );
@@ -215,9 +215,10 @@ Ext.define('Esc.magmaweb.controller.Scans', {
   /**
    * Select a scan
    * @param {Number} scanid Scan identifier
+   * @param {Boolean} [silent=false] Passing true will supress the 'unselectscan' event from being fired.
    */
-  selectScan: function(scanid) {
-    this.getChromatogram().selectScan(scanid);
+  selectScan: function(scanid, silent) {
+    this.getChromatogram().selectScan(scanid, silent);
     this.application.fireEvent('selectscan', scanid);
   },
   /**

--- a/web/magmaweb/static/esc/d3/Chromatogram.js
+++ b/web/magmaweb/static/esc/d3/Chromatogram.js
@@ -253,9 +253,10 @@ Ext.define('Esc.d3.Chromatogram', {
    * Select scan by their id
    * When there is another scan already selected the unselectscan event is fired.
    * @param {Number} scanid Scan identifier.
+   * @param {Boolean} [silent=false] Passing true will supress the 'unselectscan' event from being fired.
    */
-  selectScan: function(scanid) {
-    if (this.selectedScan != -1 && this.selectedScan != scanid) {
+  selectScan: function(scanid, silent) {
+    if (this.selectedScan != -1 && this.selectedScan != scanid && silent !== true) {
        this.fireEvent('unselectscan', this.selectedScan);
     }
     this.markerSelect(function(d) {

--- a/web/magmaweb/tests/js/app/specs/scans.js
+++ b/web/magmaweb/tests/js/app/specs/scans.js
@@ -156,17 +156,33 @@ describe('Scans controller', function() {
     Ext.util.Observable.releaseCapture(ctrl.application);
   });
 
-  it('selectScan', function() {
-    var f = { callback: function() {} };
-    spyOn(f, 'callback').andReturn(false); // listeners dont hear any events
-    Ext.util.Observable.capture(ctrl.application, f.callback);
-    spyOn(mocked_chromatogram, 'selectScan');
+  describe('selectScan', function() {
+  	var f;
 
-    ctrl.selectScan(1133);
+  	beforeEach(function() {
+	    f = { callback: function() {} };
+	    spyOn(f, 'callback').andReturn(false); // listeners dont hear any events
+	    Ext.util.Observable.capture(ctrl.application, f.callback);
+	    spyOn(mocked_chromatogram, 'selectScan');
+  	});
 
-    expect(mocked_chromatogram.selectScan).toHaveBeenCalledWith(1133);
-    expect(f.callback).toHaveBeenCalledWith('selectscan', 1133);
-    Ext.util.Observable.releaseCapture(ctrl.application);
+  	afterEach(function() {
+    	Ext.util.Observable.releaseCapture(ctrl.application);
+    });
+
+    it('default', function() {
+	    ctrl.selectScan(1133);
+
+	    expect(mocked_chromatogram.selectScan).toHaveBeenCalledWith(1133, undefined);
+	    expect(f.callback).toHaveBeenCalledWith('selectscan', 1133);
+	});
+
+    it('silent', function() {
+	    ctrl.selectScan(1133, true);
+
+	    expect(mocked_chromatogram.selectScan).toHaveBeenCalledWith(1133, true);
+	    expect(f.callback).toHaveBeenCalledWith('selectscan', 1133);
+	});
   });
 
   describe('setScansOfMetabolites', function() {

--- a/web/magmaweb/tests/js/specs/chromatogram.spec.js
+++ b/web/magmaweb/tests/js/specs/chromatogram.spec.js
@@ -212,6 +212,18 @@ describe('Esc.d3.Chromatogram', function() {
         expect(chart.selectedScan).toEqual(5);
     });
 
+    it('another scan already selected -> deselect silenced', function() {
+        chart.selectScan(data[0].id);
+
+        spyOn(chart,'markerSelect');
+        spyOn(chart,'fireEvent');
+
+        chart.selectScan(data[1].id, true);
+
+        expect(chart.fireEvent).not.toHaveBeenCalledWith('unselectscan', 4);
+        expect(chart.selectedScan).toEqual(5);
+    });
+
     it('same scan already selected -> no deselect', function() {
         chart.selectScan(data[0].id);
 


### PR DESCRIPTION
...m firing.

Now metabolites are no longer loaded with no scan when searching for another scan.
Added unit tests and tested in Chrome and Firefox.

Following scenarios now work correctly:
- Given selected scan then searching a scan
- Given selected scan and selected metabolite then searching a scan which selected metabolite also hits
- Given selected scan and selected metabolite then searching a scan which selected metabolite does not hit

This fixes #11
