### PR TITLE
Strip trailing newline when fetching reactionsequence.

### DIFF
--- a/web/magmaweb/models.py
+++ b/web/magmaweb/models.py
@@ -26,7 +26,7 @@ class ReactionSequence(TypeDecorator):
 
     def process_bind_param(self, value, dialect):
         if value is not None and not isinstance(value, basestring):
-           value = '|'.join(value)
+           value = '\n'.join(value)
 
         return value
 
@@ -35,7 +35,7 @@ class ReactionSequence(TypeDecorator):
             return []
 
         if value is not None:
-            value = value.split('|')
+            value = value.rstrip('\n').split('\n')
 
         return value
 

--- a/web/magmaweb/tests/test_job.py
+++ b/web/magmaweb/tests/test_job.py
@@ -76,7 +76,7 @@ def populateTestingDB(session):
         mol="Molfile of dihydroxyphenyl-valerolactone",
         molformula="C11H12O4",
         origin="dihydroxyphenyl-valerolactone",
-        probability=1.0, reactionsequence=["PARENT", "CHILD"],
+        probability=1.0, reactionsequence="PARENT\nCHILD\n",
         smiles="O=C1OC(Cc2ccc(O)c(O)c2)CC1",
         reference='<a href="http://pubchem.ncbi.nlm.nih.gov/summary/summary.cgi?cid=152432">CID: 152432</a>',
         mim=208.07355, logp=2.763, nhits=1


### PR DESCRIPTION
Use newlines not '|' to split/join.
In test use list and string as input for a reactionsequence.
