### PR TITLE
Hide chromatogram when a chromatogram is loaded with only one scan.

### DIFF
--- a/web/magmaweb/static/app/controller/Scans.js
+++ b/web/magmaweb/static/app/controller/Scans.js
@@ -184,7 +184,12 @@ Ext.define('Esc.magmaweb.controller.Scans', {
     chromatogram.setData(data.scans);
     me.resetScans();
     if (data.scans.length === 0) {
+    	// when there are no scans then user should upload some
         this.showUploadForm();
+    } else if (data.scans.length === 1) {
+    	// hide when chromatogram consists of 1 scan
+    	// on molecule load the scan will be selected
+    	this.getChromatogramPanel().hide();
     }
     this.application.fireEvent('chromatogramload', chromatogram);
   },

--- a/web/magmaweb/templates/results.mak
+++ b/web/magmaweb/templates/results.mak
@@ -168,9 +168,9 @@ Ext.require('Esc.magmaweb.resultsApp');
 <%!
 import json
 %>
-
+var app;
 Ext.onReady(function() {
-    Ext.create('Esc.magmaweb.resultsApp', {
+    app = Ext.create('Esc.magmaweb.resultsApp', {
       appFolder: "${request.static_url('magmaweb:static/app')}",
       maxmslevel: ${maxmslevel},
       jobid: '${jobid}',

--- a/web/magmaweb/tests/js/app/specs/scans.js
+++ b/web/magmaweb/tests/js/app/specs/scans.js
@@ -40,6 +40,8 @@ describe('Scans controller', function() {
         spyOn(mocked_chromatogram, 'setLoading');
         spyOn(mocked_chromatogram, 'setData');
         spyOn(ctrl, 'resetScans');
+        var mocked_panel = jasmine.createSpyObj('panel', ['hide']);
+  	    spyOn(ctrl, 'getChromatogramPanel').andReturn(mocked_panel);
         var f = { callback: function() {} };
         spyOn(f, 'callback').andReturn(false); // listeners dont hear any events
         Ext.util.Observable.capture(ctrl.application, f.callback);
@@ -51,7 +53,7 @@ describe('Scans controller', function() {
         expect(mocked_chromatogram.cutoff).toEqual(1000);
         expect(mocked_chromatogram.setData).toHaveBeenCalledWith([1,2,3,4]);
         expect(ctrl.resetScans).toHaveBeenCalled();
-
+        expect(mocked_panel.hide).not.toHaveBeenCalledWith();
         expect(f.callback).toHaveBeenCalledWith('chromatogramload', jasmine.any(Object));
         Ext.util.Observable.releaseCapture(ctrl.application);
       });
@@ -61,6 +63,8 @@ describe('Scans controller', function() {
           spyOn(mocked_chromatogram, 'setLoading');
           spyOn(mocked_chromatogram, 'setData');
           spyOn(ctrl, 'resetScans');
+          var mocked_panel = jasmine.createSpyObj('panel', ['hide']);
+    	  spyOn(ctrl, 'getChromatogramPanel').andReturn(mocked_panel);
           var f = { callback: function() {} };
           spyOn(f, 'callback').andReturn(false); // listeners dont hear any events
           Ext.util.Observable.capture(ctrl.application, f.callback);
@@ -72,7 +76,7 @@ describe('Scans controller', function() {
           expect(mocked_chromatogram.cutoff).toEqual(1000);
           expect(mocked_chromatogram.setData).toHaveBeenCalledWith([1,2,3,4]);
           expect(ctrl.resetScans).toHaveBeenCalled();
-
+          expect(mocked_panel.hide).not.toHaveBeenCalledWith();
           expect(f.callback).toHaveBeenCalledWith('chromatogramload', jasmine.any(Object));
           Ext.util.Observable.releaseCapture(ctrl.application);
       });
@@ -86,6 +90,24 @@ describe('Scans controller', function() {
             msg: 'Failed to load chromatogram from server',
             sourceMethod : 'loadChromatogramCallback', sourceClass : 'Esc.magmaweb.controller.Scans'
         });
+      });
+
+      it('when has a single scan then hide chromatogram', function() {
+          spyOn(mocked_chromatogram, 'setLoading');
+          spyOn(mocked_chromatogram, 'setData');
+          spyOn(ctrl, 'resetScans');
+    	  var mocked_panel = jasmine.createSpyObj('panel', ['hide']);
+    	  spyOn(ctrl, 'getChromatogramPanel').andReturn(mocked_panel);
+          var f = { callback: function() {} };
+          spyOn(f, 'callback').andReturn(false); // listeners dont hear any events
+          Ext.util.Observable.capture(ctrl.application, f.callback);
+
+          var data = { scans:[1], cutoff:null };
+          ctrl.loadChromatogramCallback(data);
+
+          expect(mocked_panel.hide).toHaveBeenCalledWith();
+          expect(f.callback).toHaveBeenCalledWith('chromatogramload', jasmine.any(Object));
+          Ext.util.Observable.releaseCapture(ctrl.application);
       });
   });
 


### PR DESCRIPTION
Fixes #53.
