### PR TITLE
Upgraded to ExtJS-4.2.0 beta.

### DIFF
--- a/web/README.txt
+++ b/web/README.txt
@@ -143,7 +143,7 @@ Python documentation generation with
   make html
 
 Javascript documentation generation with
-  jsduck magmaweb/static/ext-4.1.1a/src magmaweb/static/ext-4.1.1a/examples/ux magmaweb/static/d3/d3.v2.js magmaweb/static/esc magmaweb/static/app --builtin-classes --output jsdoc --images magmaweb/static/ext-4.1.1a/docs/images
+  jsduck magmaweb/static/extjs-4.2.0/src magmaweb/static/extjs-4.2.0/examples/ux magmaweb/static/d3/d3.v2.js magmaweb/static/esc magmaweb/static/app --builtin-classes --output jsdoc --images magmaweb/static/extjs-4.2.0/docs/images
 or minimal
   jsduck magmaweb/static/esc magmaweb/static/app --output jsdoc
 
@@ -175,8 +175,8 @@ use warnings;
 use JSON;
 
 my %paths = (
-   'Ext' => 'static/ext-4.1.1a/src',
-   'Ux'  => 'static/ext-4.1.1a/examples/ux',
+   'Ext' => 'static/extjs-4.2.0/src',
+   'Ux'  => 'static/extjs-4.2.0/examples/ux',
    'Esc' => 'static/esc',
    'App' => 'static/app'
 );

--- a/web/magmaweb/magmaweb.results-4.2.0.jsb3
+++ b/web/magmaweb/magmaweb.results-4.2.0.jsb3
@@ -1,0 +1,1178 @@
+{
+   "resources" : [],
+   "licenseText" : "Copyright(c) 2011 Netherlands eScience Center",
+   "projectName" : "MAGMA web results",
+   "builds" : [
+      {
+         "target" : "resultsApp-all-4.2.0.js",
+         "files" : [
+            {
+               "name" : "Floating.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "ElementContainer.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "ProtoElement.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Renderable.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "CubicBezier.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "Easing.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "HashMap.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Provider.js",
+               "path" : "static/extjs-4.2.0/src/state/"
+            },
+            {
+               "name" : "Target.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "Filter.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Sorter.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Color.js",
+               "path" : "static/extjs-4.2.0/src/draw/"
+            },
+            {
+               "name" : "AbstractManager.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "ComponentManager.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "ComponentQuery.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Manager.js",
+               "path" : "static/extjs-4.2.0/src/state/"
+            },
+            {
+               "name" : "Stateful.js",
+               "path" : "static/extjs-4.2.0/src/state/"
+            },
+            {
+               "name" : "Queue.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "Element.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "ElementCSS.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "CompositeElement.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "CompositeElementCSS.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "Sprite.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "CompositeSprite.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "Component.js",
+               "path" : "static/extjs-4.2.0/src/fx/target/"
+            },
+            {
+               "name" : "AbstractMixedCollection.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Sortable.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "MixedCollection.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Manager.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "Animator.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "Draw.js",
+               "path" : "static/extjs-4.2.0/src/draw/"
+            },
+            {
+               "name" : "PropertyHandler.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "Anim.js",
+               "path" : "static/extjs-4.2.0/src/fx/"
+            },
+            {
+               "name" : "Animate.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "AbstractComponent.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Component.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "EventBus.js",
+               "path" : "static/extjs-4.2.0/src/app/"
+            },
+            {
+               "name" : "Controller.js",
+               "path" : "static/extjs-4.2.0/src/app/"
+            },
+            {
+               "name" : "Application.js",
+               "path" : "static/extjs-4.2.0/src/app/"
+            },
+            {
+               "name" : "Img.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Spacer.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "Memento.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "KeyMap.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Splitter.js",
+               "path" : "static/extjs-4.2.0/src/resizer/"
+            },
+            {
+               "name" : "Layout.js",
+               "path" : "static/extjs-4.2.0/src/layout/"
+            },
+            {
+               "name" : "Proxy.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "DockingContainer.js",
+               "path" : "static/extjs-4.2.0/src/container/"
+            },
+            {
+               "name" : "Component.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "Abstract.js",
+               "path" : "static/esc/d3/"
+            },
+            {
+               "name" : "ZIndexManager.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "StatusProxy.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "Fill.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "FieldAncestor.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "Feature.js",
+               "path" : "static/extjs-4.2.0/src/grid/feature/"
+            },
+            {
+               "name" : "Bindable.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Tree.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "KeyNav.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Item.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "Errors.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "StoreManager.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "CheckboxManager.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "RadioManager.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "NodeCache.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "Operation.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Auto.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "Action.js",
+               "path" : "static/extjs-4.2.0/src/form/action/"
+            },
+            {
+               "name" : "Connection.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Offset.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "None.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/boxOverflow/"
+            },
+            {
+               "name" : "ClickRepeater.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "VTypes.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Labelable.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "Field.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/field/"
+            },
+            {
+               "name" : "Field.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "BoundList.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "TextMetrics.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "CSS.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "LruCache.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Group.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "AbstractPlugin.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "DragTracker.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "SortTypes.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Types.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Separator.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "Manager.js",
+               "path" : "static/extjs-4.2.0/src/menu/"
+            },
+            {
+               "name" : "Button.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "ComponentDragger.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "ProgressBar.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "Tab.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "FieldContainer.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/field/"
+            },
+            {
+               "name" : "LoadMask.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Ajax.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Writer.js",
+               "path" : "static/extjs-4.2.0/src/data/writer/"
+            },
+            {
+               "name" : "IdGenerator.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "validations.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "ResultSet.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Association.js",
+               "path" : "static/extjs-4.2.0/src/data/association/"
+            },
+            {
+               "name" : "Registry.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "BorderSplitter.js",
+               "path" : "static/extjs-4.2.0/src/resizer/"
+            },
+            {
+               "name" : "Container.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Border.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Dock.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "Table.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Chromatogram.js",
+               "path" : "static/esc/d3/"
+            },
+            {
+               "name" : "FiltersFeature.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/"
+            },
+            {
+               "name" : "Auto.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "AbstractContainer.js",
+               "path" : "static/extjs-4.2.0/src/container/"
+            },
+            {
+               "name" : "Container.js",
+               "path" : "static/extjs-4.2.0/src/container/"
+            },
+            {
+               "name" : "Viewport.js",
+               "path" : "static/extjs-4.2.0/src/container/"
+            },
+            {
+               "name" : "Header.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "TextItem.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "FieldSet.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "Model.js",
+               "path" : "static/extjs-4.2.0/src/selection/"
+            },
+            {
+               "name" : "RowModel.js",
+               "path" : "static/extjs-4.2.0/src/selection/"
+            },
+            {
+               "name" : "CheckboxModel.js",
+               "path" : "static/extjs-4.2.0/src/selection/"
+            },
+            {
+               "name" : "TreeModel.js",
+               "path" : "static/extjs-4.2.0/src/selection/"
+            },
+            {
+               "name" : "ColumnComponentLayout.js",
+               "path" : "static/extjs-4.2.0/src/grid/"
+            },
+            {
+               "name" : "Load.js",
+               "path" : "static/extjs-4.2.0/src/form/action/"
+            },
+            {
+               "name" : "Region.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "DragDropManager.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "Submit.js",
+               "path" : "static/extjs-4.2.0/src/form/action/"
+            },
+            {
+               "name" : "Base.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Display.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Checkbox.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Radio.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "TableLayout.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "HeaderResizer.js",
+               "path" : "static/extjs-4.2.0/src/grid/plugin/"
+            },
+            {
+               "name" : "Field.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "NodeInterface.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "DragDrop.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DD.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DDProxy.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DragSource.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DD.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "Scroller.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/boxOverflow/"
+            },
+            {
+               "name" : "Button.js",
+               "path" : "static/extjs-4.2.0/src/button/"
+            },
+            {
+               "name" : "FileButton.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Menu.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/boxOverflow/"
+            },
+            {
+               "name" : "Box.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "HBox.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "VBox.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Toolbar.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "AbstractPanel.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "ButtonGroup.js",
+               "path" : "static/extjs-4.2.0/src/container/"
+            },
+            {
+               "name" : "Table.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "ColumnLayout.js",
+               "path" : "static/extjs-4.2.0/src/grid/"
+            },
+            {
+               "name" : "Trigger.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/field/"
+            },
+            {
+               "name" : "ComboBox.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/field/"
+            },
+            {
+               "name" : "Anchor.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Window.js",
+               "path" : "static/extjs-4.2.0/src/window/"
+            },
+            {
+               "name" : "ProgressBar.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Text.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/field/"
+            },
+            {
+               "name" : "TextArea.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/field/"
+            },
+            {
+               "name" : "Text.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "TextArea.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Trigger.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "File.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Spinner.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Number.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Paging.js",
+               "path" : "static/extjs-4.2.0/src/toolbar/"
+            },
+            {
+               "name" : "MessageBox.js",
+               "path" : "static/extjs-4.2.0/src/window/"
+            },
+            {
+               "name" : "Basic.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "UploadForm.js",
+               "path" : "static/app/view/scan/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/app/view/scan/"
+            },
+            {
+               "name" : "Picker.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "Fit.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Card.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "Tab.js",
+               "path" : "static/extjs-4.2.0/src/tab/"
+            },
+            {
+               "name" : "Bar.js",
+               "path" : "static/extjs-4.2.0/src/tab/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/extjs-4.2.0/src/tab/"
+            },
+            {
+               "name" : "FieldContainer.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "CheckboxGroup.js",
+               "path" : "static/extjs-4.2.0/src/layout/container/"
+            },
+            {
+               "name" : "CheckboxGroup.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "RadioGroup.js",
+               "path" : "static/extjs-4.2.0/src/form/"
+            },
+            {
+               "name" : "AnnotateFieldSet.js",
+               "path" : "static/app/view/fragment/"
+            },
+            {
+               "name" : "Json.js",
+               "path" : "static/extjs-4.2.0/src/data/writer/"
+            },
+            {
+               "name" : "DataViewModel.js",
+               "path" : "static/extjs-4.2.0/src/selection/"
+            },
+            {
+               "name" : "AbstractView.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "View.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "Table.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "View.js",
+               "path" : "static/extjs-4.2.0/src/grid/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/extjs-4.2.0/src/grid/"
+            },
+            {
+               "name" : "BoundList.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "BoundListKeyNav.js",
+               "path" : "static/extjs-4.2.0/src/view/"
+            },
+            {
+               "name" : "ComboBox.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "MetabolizeFieldSet.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "AddFieldSet.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "AddForm.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "Reader.js",
+               "path" : "static/extjs-4.2.0/src/data/reader/"
+            },
+            {
+               "name" : "Json.js",
+               "path" : "static/extjs-4.2.0/src/data/reader/"
+            },
+            {
+               "name" : "Proxy.js",
+               "path" : "static/extjs-4.2.0/src/data/proxy/"
+            },
+            {
+               "name" : "AbstractStore.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "TreeStore.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Server.js",
+               "path" : "static/extjs-4.2.0/src/data/proxy/"
+            },
+            {
+               "name" : "Ajax.js",
+               "path" : "static/extjs-4.2.0/src/data/proxy/"
+            },
+            {
+               "name" : "Client.js",
+               "path" : "static/extjs-4.2.0/src/data/proxy/"
+            },
+            {
+               "name" : "Memory.js",
+               "path" : "static/extjs-4.2.0/src/data/proxy/"
+            },
+            {
+               "name" : "ModelManager.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Model.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Store.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "NodeStore.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "View.js",
+               "path" : "static/extjs-4.2.0/src/tree/"
+            },
+            {
+               "name" : "DragZone.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DragZone.js",
+               "path" : "static/extjs-4.2.0/src/grid/header/"
+            },
+            {
+               "name" : "ScrollManager.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DDTarget.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DropTarget.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DropZone.js",
+               "path" : "static/extjs-4.2.0/src/dd/"
+            },
+            {
+               "name" : "DropZone.js",
+               "path" : "static/extjs-4.2.0/src/grid/header/"
+            },
+            {
+               "name" : "HeaderReorderer.js",
+               "path" : "static/extjs-4.2.0/src/grid/plugin/"
+            },
+            {
+               "name" : "Container.js",
+               "path" : "static/extjs-4.2.0/src/grid/header/"
+            },
+            {
+               "name" : "Column.js",
+               "path" : "static/extjs-4.2.0/src/grid/column/"
+            },
+            {
+               "name" : "Number.js",
+               "path" : "static/extjs-4.2.0/src/grid/column/"
+            },
+            {
+               "name" : "Column.js",
+               "path" : "static/esc/chemdoodle/"
+            },
+            {
+               "name" : "Boolean.js",
+               "path" : "static/extjs-4.2.0/src/grid/column/"
+            },
+            {
+               "name" : "Template.js",
+               "path" : "static/extjs-4.2.0/src/grid/column/"
+            },
+            {
+               "name" : "Action.js",
+               "path" : "static/extjs-4.2.0/src/grid/column/"
+            },
+            {
+               "name" : "List.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "Column.js",
+               "path" : "static/extjs-4.2.0/src/tree/"
+            },
+            {
+               "name" : "Panel.js",
+               "path" : "static/extjs-4.2.0/src/tree/"
+            },
+            {
+               "name" : "Tree.js",
+               "path" : "static/app/view/fragment/"
+            },
+            {
+               "name" : "Viewport.js",
+               "path" : "static/app/view/"
+            },
+            {
+               "name" : "Scans.js",
+               "path" : "static/app/controller/"
+            },
+            {
+               "name" : "Metabolite.js",
+               "path" : "static/app/model/"
+            },
+            {
+               "name" : "Metabolites.js",
+               "path" : "static/app/store/"
+            },
+            {
+               "name" : "MSpectra.js",
+               "path" : "static/esc/d3/"
+            },
+            {
+               "name" : "Inflector.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Metabolites.js",
+               "path" : "static/app/controller/"
+            },
+            {
+               "name" : "MSpectras.js",
+               "path" : "static/app/controller/"
+            },
+            {
+               "name" : "HasMany.js",
+               "path" : "static/extjs-4.2.0/src/data/association/"
+            },
+            {
+               "name" : "Fragment.js",
+               "path" : "static/app/model/"
+            },
+            {
+               "name" : "Fragments.js",
+               "path" : "static/app/store/"
+            },
+            {
+               "name" : "Fragments.js",
+               "path" : "static/app/controller/"
+            },
+            {
+               "name" : "resultsApp.js",
+               "path" : "static/app/"
+            },
+            {
+               "name" : "Point.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Layer.js",
+               "path" : "static/extjs-4.2.0/src/dom/"
+            },
+            {
+               "name" : "PluginManager.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Resizer.js",
+               "path" : "static/extjs-4.2.0/src/resizer/"
+            },
+            {
+               "name" : "SplitterTracker.js",
+               "path" : "static/extjs-4.2.0/src/resizer/"
+            },
+            {
+               "name" : "BorderSplitterTracker.js",
+               "path" : "static/extjs-4.2.0/src/resizer/"
+            },
+            {
+               "name" : "Body.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "FieldSet.js",
+               "path" : "static/extjs-4.2.0/src/layout/component/"
+            },
+            {
+               "name" : "CellModel.js",
+               "path" : "static/extjs-4.2.0/src/selection/"
+            },
+            {
+               "name" : "Batch.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Request.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "Grouper.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "BufferedRenderer.js",
+               "path" : "static/extjs-4.2.0/src/grid/plugin/"
+            },
+            {
+               "name" : "UploadFieldSet.js",
+               "path" : "static/app/view/scan/"
+            },
+            {
+               "name" : "MetabolizeForm.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "AnnotateForm.js",
+               "path" : "static/app/view/fragment/"
+            },
+            {
+               "name" : "ElementLoader.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Queue.js",
+               "path" : "static/extjs-4.2.0/src/util/"
+            },
+            {
+               "name" : "Array.js",
+               "path" : "static/extjs-4.2.0/src/data/reader/"
+            },
+            {
+               "name" : "Filter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "Item.js",
+               "path" : "static/extjs-4.2.0/src/menu/"
+            },
+            {
+               "name" : "LockingView.js",
+               "path" : "static/extjs-4.2.0/src/grid/"
+            },
+            {
+               "name" : "Hidden.js",
+               "path" : "static/extjs-4.2.0/src/form/field/"
+            },
+            {
+               "name" : "FocusManager.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Tip.js",
+               "path" : "static/extjs-4.2.0/src/tip/"
+            },
+            {
+               "name" : "ClassList.js",
+               "path" : "static/extjs-4.2.0/src/layout/"
+            },
+            {
+               "name" : "ComponentLoader.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "ArrayStore.js",
+               "path" : "static/extjs-4.2.0/src/data/"
+            },
+            {
+               "name" : "BooleanFilter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "DateFilter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "NumericFilter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "ListFilter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "StringFilter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "DateTimeFilter.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/filter/"
+            },
+            {
+               "name" : "CheckItem.js",
+               "path" : "static/extjs-4.2.0/src/menu/"
+            },
+            {
+               "name" : "Lockable.js",
+               "path" : "static/extjs-4.2.0/src/grid/"
+            },
+            {
+               "name" : "Separator.js",
+               "path" : "static/extjs-4.2.0/src/menu/"
+            },
+            {
+               "name" : "MetabolizeOneForm.js",
+               "path" : "static/app/view/metabolite/"
+            },
+            {
+               "name" : "KeyNav.js",
+               "path" : "static/extjs-4.2.0/src/menu/"
+            },
+            {
+               "name" : "Menu.js",
+               "path" : "static/extjs-4.2.0/src/menu/"
+            },
+            {
+               "name" : "ListMenu.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/menu/"
+            },
+            {
+               "name" : "RangeMenu.js",
+               "path" : "static/extjs-4.2.0/examples/ux/grid/menu/"
+            },
+            {
+               "name" : "ToolTip.js",
+               "path" : "static/extjs-4.2.0/src/tip/"
+            },
+            {
+               "name" : "QuickTip.js",
+               "path" : "static/extjs-4.2.0/src/tip/"
+            },
+            {
+               "name" : "QuickTipManager.js",
+               "path" : "static/extjs-4.2.0/src/tip/"
+            },
+            {
+               "name" : "Tool.js",
+               "path" : "static/extjs-4.2.0/src/panel/"
+            },
+            {
+               "name" : "ContextItem.js",
+               "path" : "static/extjs-4.2.0/src/layout/"
+            },
+            {
+               "name" : "Context.js",
+               "path" : "static/extjs-4.2.0/src/layout/"
+            },
+            {
+               "name" : "ResizeTracker.js",
+               "path" : "static/extjs-4.2.0/src/resizer/"
+            },
+            {
+               "name" : "ShadowPool.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Split.js",
+               "path" : "static/extjs-4.2.0/src/button/"
+            },
+            {
+               "name" : "Month.js",
+               "path" : "static/extjs-4.2.0/src/picker/"
+            },
+            {
+               "name" : "Shadow.js",
+               "path" : "static/extjs-4.2.0/src/"
+            },
+            {
+               "name" : "Date.js",
+               "path" : "static/extjs-4.2.0/src/picker/"
+            }
+         ],
+         "compress" : true,
+         "name" : "All Classes"
+      }
+   ]
+}

--- a/web/magmaweb/static/app/resultsApp.js
+++ b/web/magmaweb/static/app/resultsApp.js
@@ -22,6 +22,7 @@
  */
 Ext.define('Esc.magmaweb.resultsApp', {
   name: 'Esc.magmaweb',
+  appFolder: Ext.Loader.getPath('Esc.magmaweb'),
   extend:'Ext.app.Application',
   constructor: function(config) {
     console.log('Construct app');

--- a/web/magmaweb/templates/results.mak
+++ b/web/magmaweb/templates/results.mak
@@ -171,7 +171,6 @@ import json
 var app;
 Ext.onReady(function() {
     app = Ext.create('Esc.magmaweb.resultsApp', {
-      appFolder: "${request.static_url('magmaweb:static/app')}",
       maxmslevel: ${maxmslevel},
       jobid: '${jobid}',
       canRun: ${json.dumps(canRun)|n},

--- a/web/magmaweb/tests/js/SpecRunner.html
+++ b/web/magmaweb/tests/js/SpecRunner.html
@@ -7,10 +7,10 @@
 <link rel="stylesheet" href="lib/jasmine-1.2.0/jasmine.css" type="text/css"></link>
 
 <link rel="stylesheet" href="../../static/ChemDoodleWeb/ChemDoodleWeb.css" type="text/css">
-<link rel="stylesheet" href="../../static/ext-4.1.1a/resources/css/ext-all.css" type="text/css">
-<link rel="stylesheet" type="text/css" href="../../static/ext-4.1.1a/examples/ux/grid/css/GridFilters.css" />
-<link rel="stylesheet" type="text/css" href="../../static/ext-4.1.1a/examples/ux/grid/css/RangeMenu.css" />
-<script type="text/javascript" src="../../static/ext-4.1.1a/ext-all-debug.js"></script>
+<link rel="stylesheet" href="../../static/extjs-4.2.0/resources/css/ext-all.css" type="text/css">
+<link rel="stylesheet" type="text/css" href="../../static/extjs-4.2.0/examples/ux/grid/css/GridFilters.css" />
+<link rel="stylesheet" type="text/css" href="../../static/extjs-4.2.0/examples/ux/grid/css/RangeMenu.css" />
+<script type="text/javascript" src="../../static/extjs-4.2.0/ext-all-debug.js"></script>
 <script type="text/javascript" src="../../static/ChemDoodleWeb/ChemDoodleWeb-libs.js"></script>
 <script type="text/javascript" src="../../static/ChemDoodleWeb/ChemDoodleWeb.js"></script>
 <script type="text/javascript" src="../../static/d3/d3.v2.js"></script>
@@ -28,7 +28,7 @@ Ext.Loader.setConfig({
   enabled: true,
   paths: {
     'Esc': '../../static/esc',
-    'Ext.ux': '../../static/ext-4.1.1a/examples/ux'
+    'Ext.ux': '../../static/extjs-4.2.0/examples/ux'
   }
 });
 Ext.require([

--- a/web/magmaweb/tests/js/app/app-test.js
+++ b/web/magmaweb/tests/js/app/app-test.js
@@ -4,15 +4,16 @@ Ext.Loader.setConfig({
   paths: {
     'Esc.magmaweb': '../../../static/app',
     'Esc': '../../../static/esc',
-    'Ext.ux': '../../../static/ext-4.1.1a/examples/ux'
+    'Ext.ux': '../../../static/extjs-4.2.0/examples/ux'
   }
 });
+
+Ext.require('Esc.magmaweb.resultsApp');
 
 var Application = null;
 
 Ext.onReady(function() {
   Application = Ext.create('Esc.magmaweb.resultsApp', {
-      appFolder: "../../../static/app",
       maxmslevel: 3,
       jobid: '3ad25048-26f6-11e1-851e-00012e260790',
       urls: {
@@ -33,8 +34,6 @@ Ext.onReady(function() {
       // use test files for metabolites in data/
       metabolitesUrl: function(format) {
           return 'data/metabolites.'+format;
-      },
-      // do not create views, all tests mock views
-      autoCreateViewport: false
+      }
   });
 });

--- a/web/magmaweb/tests/js/app/run-tests.html
+++ b/web/magmaweb/tests/js/app/run-tests.html
@@ -4,7 +4,7 @@
 
     <link rel="stylesheet" type="text/css" href="../lib/jasmine-1.2.0/jasmine.css">
 
-    <script type="text/javascript" src="../../../static/ext-4.1.1a/ext-debug.js"></script>
+    <script type="text/javascript" src="../../../static/extjs-4.2.0/ext-debug.js"></script>
     <script type="text/javascript" src="../../../static/ChemDoodleWeb/ChemDoodleWeb-libs.js"></script>
     <script type="text/javascript" src="../../../static/ChemDoodleWeb/ChemDoodleWeb.js"></script>
     <script type="text/javascript" src="../../../static/d3/d3.v2.js"></script>

--- a/web/magmaweb/tests/js/app/specs/fragments.js
+++ b/web/magmaweb/tests/js/app/specs/fragments.js
@@ -372,7 +372,8 @@ describe('Fragments', function() {
                 precursor_mz_precision: '0.001',
                 ms_intensity_cutoff: '200000',
                 msms_intensity_cutoff: '0.1',
-                mz_precision: '0.001'
+                mz_precision: '5',
+                mz_precision_abs: '0.001'
             });
         });
         expect(ctrl.annotateForm.isVisible()).toBeTruthy();

--- a/web/magmaweb/tests/js/app/specs/scans.js
+++ b/web/magmaweb/tests/js/app/specs/scans.js
@@ -25,11 +25,12 @@ describe('Scans controller', function() {
 	mocked_form = {
 		submit: function() {},
 		isValid: function() { return true; },
+		setValues: function() {},
 		load: function() {}
 	};
 	mocked_form_panel = {
 		setDisabledAnnotateFieldset: function() {},
-		setDefaults: function() {},
+		loadDefaults: function() {},
 		getForm: function() { return mocked_form; }
 	};
 	spyOn(ctrl, 'getUploadForm').andReturn(mocked_form_panel);
@@ -420,7 +421,7 @@ describe('Scans controller', function() {
   });
 
   it('uploadHandler', function() {
-	  spyOn(mocked_form, 'isValid');
+	  spyOn(mocked_form, 'isValid').andReturn(true);
       spyOn(mocked_form, 'submit');
 	  
       ctrl.uploadHandler();
@@ -433,6 +434,16 @@ describe('Scans controller', function() {
           success: jasmine.any(Function),
           failure: jasmine.any(Function)
       });
+  });
+
+  it('uploadHandler with invalid form', function() {
+	  spyOn(mocked_form, 'isValid').andReturn(false);
+      spyOn(mocked_form, 'submit');
+
+      ctrl.uploadHandler();
+
+	  expect(mocked_form.isValid).toHaveBeenCalledWith();
+      expect(mocked_form.submit).not.toHaveBeenCalled();
   });
 
   it('showActionsMenu', function() {

--- a/web/production.ini-dist
+++ b/web/production.ini-dist
@@ -20,7 +20,7 @@ cookie.path = /magma
 sqlalchemy.url = sqlite:///%(here)s/data/users.db
 
 # In magmaweb/static/ which ExtJS directory to use
-extjsroot = ext-4.1.1a
+extjsroot = extjs-4.2.0
 
 jobfactory.root_dir = %(here)s/data/jobs
 # url to which job request is submitted


### PR DESCRIPTION
The new ExtJS does Ext.Loader.setPath on extending of Ext.app.Application.
The appFolder setting used during creation of Esc.magmaweb.resultsApp was ignored
and the application crashed with an error of not finding /magma/results/app/view/Viewport.js (it should be /magma/static/app/view/Viewport.js).
So the appFolder is now set during the define of Esc.magmaweb.resultsApp using Ext.Loader.getPath('Esc.magmaweb').
Now the application runs as before.
The mask is removed from the page when loading of the forms defaults completes (fixes #35).
Also weird behavoir of combos when mask was removed manually, no longer appears.

Used wrong function name in scans testcase for issue #83.
The scans uploadHandler() was not tested when form is invalid.

Forgot to add 'mz_precision_abs' to javascript tests (refs #57).
