### PR TITLE
When switching back to 'mzxml' ms format restore the filtering to their ...

### DIFF
--- a/web/magmaweb/static/app/controller/Scans.js
+++ b/web/magmaweb/static/app/controller/Scans.js
@@ -402,16 +402,25 @@ Ext.define('Esc.magmaweb.controller.Scans', {
   /**
    * Called when MS data format is changed.
    * When the 'tree' format is chosen the filtering is disabled.
-   * When a non-'tree' format is chosen filtering is left intact.
+   * When a non-'tree' format is chosen the filtering is restored
+   * to what it was before 'tree' format was chosen.
    */
   changeMsDataFormat: function(field, value) {
-      var form = this.getUploadForm().getForm();
+	  var form = this.getUploadForm().getForm();
 	  if (value == 'tree') {
-		  form.setValues({
-		      'ms_intensity_cutoff': 0,
-		      'msms_intensity_cutoff': 0,
-		      'abs_peak_cutoff': 0
-		  });
+		  var values = form.getValues();
+		  filters_before_tree = {
+		      'ms_intensity_cutoff': values['ms_intensity_cutoff'],
+		      'msms_intensity_cutoff': values['msms_intensity_cutoff'],
+	          'abs_peak_cutoff': values['abs_peak_cutoff']
+		  };
+	      form.setValues({
+			  'ms_intensity_cutoff': 0,
+			  'msms_intensity_cutoff': 0,
+			  'abs_peak_cutoff': 0
+	      });
+	  } else {
+		  form.setValues(filters_before_tree);
 	  }
   }
 });

--- a/web/magmaweb/templates/startjob.mak
+++ b/web/magmaweb/templates/startjob.mak
@@ -136,13 +136,22 @@ Ext.onReady(function() {
   });
   // change settings when tree ms data format is chosen.
   var ms_data_format_combo = form.down('component[name=ms_data_format]');
+  var filters_before_tree = {};
   ms_data_format_combo.addListener('change', function(field, value) {
 	if (value == 'tree') {
+		var values = form.getForm().getValues();
+		filters_before_tree = {
+            'ms_intensity_cutoff': values['ms_intensity_cutoff'],
+            'msms_intensity_cutoff': values['msms_intensity_cutoff'],
+            'abs_peak_cutoff': values['abs_peak_cutoff']
+        };
 		form.getForm().setValues({
 		    'ms_intensity_cutoff': 0,
 		    'msms_intensity_cutoff': 0,
 		    'abs_peak_cutoff': 0
 		});
+	} else {
+		form.getForm().setValues(filters_before_tree);
 	}
   });
 

--- a/web/magmaweb/tests/js/app/specs/scans.js
+++ b/web/magmaweb/tests/js/app/specs/scans.js
@@ -26,6 +26,7 @@ describe('Scans controller', function() {
 		submit: function() {},
 		isValid: function() { return true; },
 		setValues: function() {},
+		getValues: function() {},
 		load: function() {}
 	};
 	mocked_form_panel = {
@@ -423,7 +424,7 @@ describe('Scans controller', function() {
   it('uploadHandler', function() {
 	  spyOn(mocked_form, 'isValid').andReturn(true);
       spyOn(mocked_form, 'submit');
-	  
+
       ctrl.uploadHandler();
 
 	  expect(mocked_form.isValid).toHaveBeenCalledWith();
@@ -513,27 +514,40 @@ describe('Scans controller', function() {
 	  };
 	  expect(mocked_form.load).toHaveBeenCalledWith(expected);
   });
-  
+
   describe('changeMsDataFormat', function() {
 	it('tree', function() {
+		var filter_init = {
+				'ms_intensity_cutoff': 1,
+			    'msms_intensity_cutoff': 2,
+			    'abs_peak_cutoff': 3
+		};
+		spyOn(mocked_form, 'getValues').andReturn(filter_init);
 		spyOn(mocked_form, 'setValues');
-		
+
 		ctrl.changeMsDataFormat(null, 'tree');
-		
-		filter_off = {
+
+		var filter_off = {
 			'ms_intensity_cutoff': 0,
 		    'msms_intensity_cutoff': 0,
 		    'abs_peak_cutoff': 0
 		};
 		expect(mocked_form.setValues).toHaveBeenCalledWith(filter_off);
 	});
-	
+
 	it('non-tree', function() {
+		var filter_init = {
+				'ms_intensity_cutoff': 1,
+			    'msms_intensity_cutoff': 2,
+			    'abs_peak_cutoff': 3
+		};
+		spyOn(mocked_form, 'getValues').andReturn(filter_init);
 		spyOn(mocked_form, 'setValues');
-		
+		ctrl.changeMsDataFormat(null, 'tree');
+
 		ctrl.changeMsDataFormat(null, 'mzxml');
-		
-		expect(mocked_form.setValues).not.toHaveBeenCalled();
+
+		expect(mocked_form.setValues).toHaveBeenCalledWith(filter_init);
 	});
   });
 });


### PR DESCRIPTION
...original values before a 'tree' switch was done (fixes #52).
