### PR TITLE
For now remove interactive buttons from result page for everyone

### DIFF
--- a/web/magmaweb/static/app/controller/Fragments.js
+++ b/web/magmaweb/static/app/controller/Fragments.js
@@ -394,10 +394,10 @@ Ext.define('Esc.magmaweb.controller.Fragments', {
   },
   /**
    * Apply role to user interface.
-   * Checks canRun and if false removes all action buttons.
+   * Checks canAssign and if false removes all assign action buttons.
    */
   applyRole: function() {
-	  if (this.application.canRun) {
+	  if (this.application.canAssign) {
 		  return;
 	  }
 	  this.getAssignStruct2PeakButton().hide();

--- a/web/magmaweb/static/app/resultsApp.js
+++ b/web/magmaweb/static/app/resultsApp.js
@@ -49,10 +49,15 @@ Ext.define('Esc.magmaweb.resultsApp', {
      */
     jobid: null,
     /**
-     * Whether user has rights to run actions like add structures or assign a peak to a structure.
+     * Whether user has rights to run actions like add structures or re-annotate.
      * @cfg {Boolean}
      */
     canRun: true,
+    /**
+     * Whether user has rights to (un)assign a peak to a structure.
+     * @cfg {Boolean}
+     */
+    canAssign: true,
     /**
      * Whether user is logged in, shows login or logout button.
      * @cfg {Boolean}

--- a/web/magmaweb/templates/results.mak
+++ b/web/magmaweb/templates/results.mak
@@ -80,7 +80,8 @@ Ext.onReady(function() {
     app = Ext.create('Esc.magmaweb.resultsApp', {
       maxmslevel: ${maxmslevel},
       jobid: '${jobid}',
-      canRun: ${json.dumps(canRun)|n},
+      canRun: false, // don't allow starting job runs from results page
+      canAssign: ${json.dumps(canRun)|n},
       is_user_authenticated: ${json.dumps(request.user is not None)},
       urls: {
         home: '${request.route_path('home')}',

--- a/web/magmaweb/templates/startjob.mak
+++ b/web/magmaweb/templates/startjob.mak
@@ -228,6 +228,10 @@ Ext.onReady(function() {
   };
 
   user_authenticated(${json.dumps(request.user is not None)});
+
+  // hide interactive job run starting points
+  Ext.ComponentQuery.query('component[text=Start from scratch]')[0].hide();
+  Ext.ComponentQuery.query('component[text=Upload result]')[0].disable();
 });
 </script>
 </head>

--- a/web/magmaweb/tests/js/app/specs/fragments.js
+++ b/web/magmaweb/tests/js/app/specs/fragments.js
@@ -584,8 +584,8 @@ describe('Fragments', function() {
     	expect(ctrl.applyRole).toHaveBeenCalledWith();
     });
 
-    it('canrun', function() {
-  	  ctrl.application.canRun = true;
+    it('canassign', function() {
+  	  ctrl.application.canAssign = true;
       assignbut = jasmine.createSpyObj('abut', [ 'hide']);
       spyOn(ctrl,'getAssignStruct2PeakButton').andReturn(assignbut);
 
@@ -594,8 +594,8 @@ describe('Fragments', function() {
   	  expect(assignbut.hide).not.toHaveBeenCalledWith();
     });
 
-    it('cantrun', function() {
-  	  ctrl.application.canRun = false;
+    it('cantassign', function() {
+  	  ctrl.application.canAssign = false;
       assignbut = jasmine.createSpyObj('abut', [ 'hide']);
       spyOn(ctrl,'getAssignStruct2PeakButton').andReturn(assignbut);
 


### PR DESCRIPTION
Make version of app where it isn't possible to start jobs from the result page.

Now only owners can run + assign using canRun: true option

Add canAssign option 
