### PR TITLE
Status reload was only change in meta tag not in body (fixes #98).

### DIFF
--- a/web/magmaweb/static/app/controller/Metabolites.js
+++ b/web/magmaweb/static/app/controller/Metabolites.js
@@ -240,7 +240,7 @@ Ext.define('Esc.magmaweb.controller.Metabolites', {
       var store = this.getMetabolitesStore();
       store.sorters.insert(0, new Ext.util.Sorter({
           property: 'score',
-          direction: 'DESC'
+          direction: 'ASC'
       }));
       store.setScanFilter(scanid);
       this.getMetaboliteList().showFragmentScoreColumn();

--- a/web/magmaweb/templates/status.mak
+++ b/web/magmaweb/templates/status.mak
@@ -9,6 +9,6 @@
 <meta http-equiv="refresh" content="10" />
 % endif
 </head>
-<body>Job is in '${status}' status. This page will reload every 30 seconds.
+<body>Job is in '${status}' status. This page will reload every 10 seconds.
 </body>
 </html>

--- a/web/magmaweb/tests/js/app/specs/metabolites.js
+++ b/web/magmaweb/tests/js/app/specs/metabolites.js
@@ -225,7 +225,7 @@ describe('Metabolites', function() {
        expect(list.showFragmentScoreColumn).toHaveBeenCalled();
        expect(mockedstore.setScanFilter).toHaveBeenCalledWith(scanid);
        expect(mockedstore.sorters.indexOfKey('score')).toEqual(0);
-       expect(mockedstore.sorters.getByKey('score').direction).toEqual('DESC');
+       expect(mockedstore.sorters.getByKey('score').direction).toEqual('ASC');
      });
 
      describe('clear scan filter', function() {


### PR DESCRIPTION
Candidate score was sorted in wrong direction, should have been ascending (fixes #99).
