### PR TITLE
Set less fields when example is loaded and tree format is selected.

### DIFF
--- a/web/magmaweb/job.py
+++ b/web/magmaweb/job.py
@@ -638,15 +638,6 @@ class JobQuery(object):
         return dict(ms_data="\n".join(example_tree),
                     ms_data_format='tree',
                     ionisation_mode=-1,
-                    ms_intensity_cutoff=0,
-                    msms_intensity_cutoff=0,
-                    mz_precision=5,
-                    mz_precision_abs=0,
-                    abs_peak_cutoff=1000,
-                    max_ms_level=10,
-                    precursor_mz_precision=0.005,
-                    max_broken_bonds=3,
-                    max_water_losses=1,
                     )
 
 

--- a/web/magmaweb/static/app/controller/Scans.js
+++ b/web/magmaweb/static/app/controller/Scans.js
@@ -411,13 +411,11 @@ Ext.define('Esc.magmaweb.controller.Scans', {
 		  var values = form.getValues();
 		  filters_before_tree = {
 		      'ms_intensity_cutoff': values['ms_intensity_cutoff'],
-		      'msms_intensity_cutoff': values['msms_intensity_cutoff'],
-	          'abs_peak_cutoff': values['abs_peak_cutoff']
+		      'msms_intensity_cutoff': values['msms_intensity_cutoff']
 		  };
 	      form.setValues({
 			  'ms_intensity_cutoff': 0,
-			  'msms_intensity_cutoff': 0,
-			  'abs_peak_cutoff': 0
+			  'msms_intensity_cutoff': 0
 	      });
 	  } else {
 		  form.setValues(filters_before_tree);

--- a/web/magmaweb/templates/startjob.mak
+++ b/web/magmaweb/templates/startjob.mak
@@ -143,13 +143,11 @@ Ext.onReady(function() {
 		var values = form.getForm().getValues();
 		filters_before_tree = {
             'ms_intensity_cutoff': values['ms_intensity_cutoff'],
-            'msms_intensity_cutoff': values['msms_intensity_cutoff'],
-            'abs_peak_cutoff': values['abs_peak_cutoff']
+            'msms_intensity_cutoff': values['msms_intensity_cutoff']
         };
 		form.getForm().setValues({
 		    'ms_intensity_cutoff': 0,
-		    'msms_intensity_cutoff': 0,
-		    'abs_peak_cutoff': 0
+		    'msms_intensity_cutoff': 0
 		});
 	} else {
 		form.getForm().setValues(filters_before_tree);

--- a/web/magmaweb/tests/test_job.py
+++ b/web/magmaweb/tests/test_job.py
@@ -1676,15 +1676,6 @@ class JobQueryTestCase(unittest.TestCase):
         expected = dict(ms_data="\n".join(example_tree),
                         ms_data_format='tree',
                         ionisation_mode=-1,
-                        ms_intensity_cutoff=0,
-                        msms_intensity_cutoff=0,
-                        mz_precision=5,
-                        mz_precision_abs=0,
-                        abs_peak_cutoff=1000,
-                        max_ms_level=10,
-                        precursor_mz_precision=0.005,
-                        max_broken_bonds=3,
-                        max_water_losses=1,
                         )
         self.assertDictEqual(expected, JobQuery.defaults('example'))
 


### PR DESCRIPTION
When selecting example tree:
1. Set ms data format to tree
2. Fill ms data textarea with example
3. Set ionisation mode
And nothing more.

When selecting tree format only set the intensity thresholds.
