### PR TITLE
Add ability to mark job as private or public.

### DIFF
--- a/web/magmaweb/job.py
+++ b/web/magmaweb/job.py
@@ -1087,6 +1087,19 @@ class Job(object):
 
     ms_filename = property(get_ms_filename, set_ms_filename)
 
+    def get_is_public(self):
+        """Whether job is public or not"""
+        return self.meta.is_public
+
+    def set_is_public(self, is_public):
+        """Set whether job is public or not
+
+        True is public and False is private
+        """
+        self.meta.is_public = is_public
+
+    is_public = property(get_is_public, set_is_public)
+
     def delete(self):
         """Deletes job from user database and deletes job directory"""
         magmaweb.user.JobMeta.delete(self.meta)

--- a/web/magmaweb/templates/workspace.mak
+++ b/web/magmaweb/templates/workspace.mak
@@ -40,6 +40,7 @@ Ext.require([
   'Ext.form.Panel',
   'Ext.grid.Panel',
   'Ext.grid.column.Date',
+  'Ext.grid.column.Boolean',
   'Ext.grid.column.Action',
   'Ext.grid.plugin.CellEditing',
   'Ext.data.proxy.Rest',
@@ -83,7 +84,8 @@ Ext.onReady(function() {
         'description',
         'ms_filename',
         {name: 'created_at', type: 'date'},
-        'url'
+        'url',
+        'is_public'
       ],
       proxy: {
         type: 'rest',
@@ -129,6 +131,14 @@ Ext.onReady(function() {
       text: 'MS filename', dataIndex: 'ms_filename',
       editor: {
         xtype: 'textfield'
+      }
+    }, {
+      text: 'Public?', dataIndex: 'is_public', width: 70,
+      xtype: 'booleancolumn',
+      trueText: 'Public',
+      falseText: 'Private',
+      editor: {
+        xtype: 'checkbox'
       }
     }, {
       text: 'Created at', dataIndex: 'created_at', width: 120,

--- a/web/magmaweb/tests/test_functional.py
+++ b/web/magmaweb/tests/test_functional.py
@@ -116,6 +116,7 @@ class FunctionalTests(unittest.TestCase):
                                "description": "New description",
                                "ms_filename": "F6789.mzxml",
                                "created_at": "1999-12-17T13:45:04",
+                               "is_public": False,
                                })
         self.testapp.put(req_url, req_body)
 
@@ -123,6 +124,7 @@ class FunctionalTests(unittest.TestCase):
                                 "description": "New description 2",
                                 "ms_filename": "F6789.mzxml 2",
                                 "created_at": "1999-12-17T13:45:04",
+                                "is_public": False,
                                 })
 
         self.testapp.put(req_url, req_body2)

--- a/web/magmaweb/tests/test_job.py
+++ b/web/magmaweb/tests/test_job.py
@@ -542,7 +542,9 @@ class JobTestCase(unittest.TestCase):
                                parentjobid=self.parentjobid,
                                owner='bob',
                                created_at=self.created_at,
-                               ms_filename='F1234.mzxml')
+                               ms_filename='F1234.mzxml',
+                               is_public=False,
+                               )
         self.db = Mock(JobDb)
         self.jobdir = tempfile.mkdtemp()
         stderr = open(os.path.join(self.jobdir, 'stderr.txt'), 'w')
@@ -656,6 +658,14 @@ class JobTestCase(unittest.TestCase):
         self.job.db.session.remove.assert_called_with()
         shutl.rmtree.assert_called_with(self.jobdir)
         jm.delete.assert_called_with(self.meta)
+
+    def test_is_public(self):
+        self.assertEquals(self.job.is_public, False)
+
+    def test_set_is_public(self):
+        self.job.is_public = True
+
+        self.assertEquals(self.job.is_public, True)
 
 
 class JobDbTestCaseAbstract(unittest.TestCase):

--- a/web/magmaweb/tests/test_user.py
+++ b/web/magmaweb/tests/test_user.py
@@ -258,10 +258,11 @@ class TestJobIdFactory(unittest.TestCase):
         destroy_user_db()
         testing.tearDown()
 
-    def test_getJob(self):
+    def test_getPrivateJob(self):
         from magmaweb.job import Job
         mjob = Mock(Job)
         mjob.owner = 'bob'
+        mjob.is_public = False
         jif = user.JobIdFactory(self.request)
         jif.job_factory.fromId = Mock(return_value=mjob)
         job_id = uuid.UUID('11111111-1111-1111-1111-111111111111')
@@ -270,9 +271,29 @@ class TestJobIdFactory(unittest.TestCase):
 
         jif.job_factory.fromId.assert_called_once_with(job_id)
         self.assertEqual(job, mjob)
-        self.assertEqual(job.__parent__, jif)
-        self.assertEqual(job.__acl__, [(Allow, 'bob', 'run'),
-                                       (Allow, 'jobmanager', 'monitor')])
+        self.assertEqual(job.__acl__, [(Allow, 'bob', ('run', 'view')),
+                                       (Allow, 'jobmanager', 'monitor'),
+                                       (Deny, Everyone, ALL_PERMISSIONS),
+                                       ])
+
+    def test_getPublicJob(self):
+        from magmaweb.job import Job
+        mjob = Mock(Job)
+        mjob.owner = 'bob'
+        mjob.is_public = True
+        jif = user.JobIdFactory(self.request)
+        jif.job_factory.fromId = Mock(return_value=mjob)
+        job_id = uuid.UUID('11111111-1111-1111-1111-111111111111')
+
+        job = jif[str(job_id)]
+
+        jif.job_factory.fromId.assert_called_once_with(job_id)
+        self.assertEqual(job, mjob)
+        self.assertEqual(job.__acl__, [(Allow, Authenticated, 'view'),
+                                       (Allow, 'bob', ('run', 'view')),
+                                       (Allow, 'jobmanager', 'monitor'),
+                                       (Deny, Everyone, ALL_PERMISSIONS),
+                                       ])
 
     def test_getJobNotFound(self):
         from magmaweb.job import JobNotFound
@@ -283,3 +304,4 @@ class TestJobIdFactory(unittest.TestCase):
 
         with self.assertRaises(HTTPNotFound):
             jif[str(jobid)]
+

--- a/web/magmaweb/tests/test_views.py
+++ b/web/magmaweb/tests/test_views.py
@@ -192,7 +192,8 @@ class ViewsTestCase(AbstractViewsTestCase):
         created_at = datetime.datetime(2012, 11, 14, 10, 48, 26, 504478)
         jobs = [JobMeta(uuid.UUID('11111111-1111-1111-1111-111111111111'),
                         'bob', description='My job', created_at=created_at,
-                        ms_filename='F1234.mzxml')]
+                        ms_filename='F1234.mzxml',
+                        is_public=False,)]
         request.user.jobs = jobs
         views = Views(request)
 
@@ -203,6 +204,7 @@ class ViewsTestCase(AbstractViewsTestCase):
         expected_jobs = [{'id': '11111111-1111-1111-1111-111111111111',
                           'url': url1,
                           'description': 'My job',
+                          'is_public': False,
                           'ms_filename': 'F1234.mzxml',
                           'created_at': '2012-11-14T10:48:26'}]
         self.assertEqual(response, {'jobs': expected_jobs})
@@ -732,6 +734,8 @@ class JobViewsTestCase(AbstractViewsTestCase):
                                     'data': dict(n_reaction_steps=2,
                                                  metabolism_types=['phase1',
                                                                    'phase2'],
+                                                 ms_data_area='',
+                                                 ms_data_format='mzxml',
                                                  ionisation_mode=-1,
                                                  ms_intensity_cutoff=200000.0,
                                                  msms_intensity_cutoff=50,
@@ -759,6 +763,8 @@ class JobViewsTestCase(AbstractViewsTestCase):
                                     'data': dict(n_reaction_steps=2,
                                                  metabolism_types=['phase1',
                                                                    'phase2'],
+                                                 ms_data_area='',
+                                                 ms_data_format='mzxml',
                                                  ionisation_mode=1,
                                                  ms_intensity_cutoff=1000000.0,
                                                  msms_intensity_cutoff=10,
@@ -784,6 +790,8 @@ class JobViewsTestCase(AbstractViewsTestCase):
                                     'data': dict(n_reaction_steps=2,
                                                  metabolism_types=['phase1',
                                                                    'phase2'],
+                                                 ms_data_area='',
+                                                 ms_data_format='mzxml',
                                                  ionisation_mode=1,
                                                  ms_intensity_cutoff=1000000.0,
                                                  msms_intensity_cutoff=10,
@@ -803,6 +811,7 @@ class JobViewsTestCase(AbstractViewsTestCase):
                              "description": "New description",
                              "ms_filename": "F12345.mzxml",
                              "created_at": "1999-12-17T13:45:04",
+                             "is_public": True,
                              }
         job = self.fake_job()
         expected_id = job.id
@@ -817,6 +826,7 @@ class JobViewsTestCase(AbstractViewsTestCase):
         self.assertEqual(job.description, 'New description')
         self.assertEqual(job.ms_filename, 'F12345.mzxml')
         self.assertEqual(job.created_at, execpted_ca)
+        self.assertEqual(job.is_public, True)
 
     def test_deletejson(self):
         request = testing.DummyRequest()

--- a/web/magmaweb/views.py
+++ b/web/magmaweb/views.py
@@ -114,6 +114,7 @@ class Views(object):
                          'description': jobmeta.description,
                          'ms_filename': jobmeta.ms_filename,
                          'created_at': created_at,
+                         'is_public': jobmeta.is_public,
                          })
 
         return {'jobs': jobs}
@@ -261,6 +262,7 @@ class JobViews(object):
         job = self.job
         job.description = body['description']
         job.ms_filename = body['ms_filename']
+        job.is_public = body['is_public']
         return {'success': True, 'message': 'Updated job'}
 
     @view_config(route_name='results',


### PR DESCRIPTION
Previously all jobs where public, ie all jobs where visible for all users.
Now by default all jobs will be private.
To make a job public you have to go to the workspace page and set the job to public.
Refs #131.
