### PR TITLE
Make STOPPED and ERROR job states where something has to happen.

### DIFF
--- a/web/magmaweb/job.py
+++ b/web/magmaweb/job.py
@@ -493,22 +493,17 @@ class Job(object):
     def is_complete(self):
         """Checks if job is complete
 
-        Returns true or raises JobException or JobIncomplete
+        Returns true or raises JobError or JobIncomplete
         """
-        # TODO redirect to status page when job is in progress
-        # progress == ('INITIAL', 'PRE_STAGING', 'RUNNING', 'POST_STAGING'
-        # or contains 'candidate molecules processed ...'
-        # TODO show error page when job.state == ERROR
         # TODO show error page when interactive==false
         # and job contains no molecules or no ms data
 
-        progress_states = ('INITIAL', 'PRE_STAGING', 'RUNNING', 'POST_STAGING')
-        if self.state in progress_states or 'processed ...' in self.state:
-            raise JobIncomplete(self)
+        if self.state == 'STOPPED':
+            return True
         elif self.state == 'ERROR':
             raise JobError(self)
         else:
-            return True
+            raise JobIncomplete(self)
 
 
 class JobDb(object):

--- a/web/magmaweb/tests/test_job.py
+++ b/web/magmaweb/tests/test_job.py
@@ -687,14 +687,17 @@ class JobTestCase(unittest.TestCase):
         self.assertEquals(self.job.is_public, True)
 
     def test_is_complete(self):
+        self.job.state = 'STOPPED'
         self.assertTrue(self.job.is_complete())
 
     def test_is_complete_running(self):
-        self.job.state = 'RUNNING'
-        with self.assertRaises(JobIncomplete) as e:
-            self.job.is_complete()
+        running_states = ('INITIAL', 'PRE_STAGING', 'RUNNING', 'POST_STAGING', 'Progress: 50%')
+        for running_state in running_states:
+            self.job.state = running_state
+            with self.assertRaises(JobIncomplete) as e:
+                self.job.is_complete()
 
-        self.assertEqual(e.exception.job, self.job)
+            self.assertEqual(e.exception.job, self.job)
 
     def test_is_complete_error(self):
         self.job.state = 'ERROR'


### PR DESCRIPTION
Other states will redirect to status page.

Refs #157.
