### PR TITLE
Use absolute urls to MAGMa and MAGMa viewer.

### DIFF
--- a/emetabolomics_site/index.html
+++ b/emetabolomics_site/index.html
@@ -34,8 +34,8 @@ body {
             <h1>The eMetabolomics research project</h1>
             <p>
                 The eMetabolomics project is funded by the <a
-                    href="http://www.esciencecenter.com">Netherlands eScience Center</a> 
-                and is carried out at <a href="http://www.wur.nl">Wageningen University</a> and the Netherlands eScience Center 
+                    href="http://www.esciencecenter.com">Netherlands eScience Center</a>
+                and is carried out at <a href="http://www.wur.nl">Wageningen University</a> and the Netherlands eScience Center
                 in collaboration with the <a href="http://www.metabolomicscentre.nl">Netherlands Metabolomics Centre</a>.
                 The project develops chemo-informatics based
                 methods for metabolite identification and biochemical network
@@ -50,7 +50,7 @@ body {
                 <p>
                     MAGMa is an online application for the automatic chemical annotation of accurate multistage MS<sup>n</sup> spectral data.
                     <ul>
-                        <li>MS<sup>n</sup> data can be uploaded as a hierarchical tree of fragment peaks, either based on m/z values or elemental formulas, 
+                        <li>MS<sup>n</sup> data can be uploaded as a hierarchical tree of fragment peaks, either based on m/z values or elemental formulas,
                         or as an mzXML file of the raw data.</li>
                         <li>Candidate molecules are automatically retrieved from PubChem, from a subset of PubChem compounds present in Kegg,
                         or from the Human Metabolome Database.</li>
@@ -59,7 +59,7 @@ body {
                     </ul>
                 </p>
                 <p>
-                    <a class="btn" href="/magma">Go to MAGMa</a>
+                    <a class="btn" href="http://www.emetabolomics.org/magma">Go to MAGMa</a>
                 </p>
                 </br>
                 <h2>Publications</h2>
@@ -68,15 +68,15 @@ body {
                     The results presented in this paper are <a href="results.html">available via the MAGMa interface</a>.
                 </p>
                 </br>
- 
+
                 <p>
                     For more information, contact: <a href="mailto:Lars.Ridder@wur.nl">Lars.Ridder@wur.nl</a>
                 </p>
- 
+
             </div>
         </div>
         </br>
- 
+
         <div class="row">
             <div class="span4">
                 <a href="http://www.esciencecenter.com"><img

--- a/emetabolomics_site/results.html
+++ b/emetabolomics_site/results.html
@@ -36,38 +36,38 @@ body {
                     the preliminary MAGMa web interface:</p>
                 <ul>
 <li><a
-                        href="/magmaviewer/results/6ae8f10c-8617-45bb-aeaf-23bea220b090">3,4-diOH-Valerolactone-sulphate</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/6ae8f10c-8617-45bb-aeaf-23bea220b090">3,4-diOH-Valerolactone-sulphate</a></li>
                     <li><a
-                        href="/magmaviewer/results/fe028841-b3ca-4152-a22d-c45d5ffab3eb">Pyrogallol-2-O-glucuronide</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/fe028841-b3ca-4152-a22d-c45d5ffab3eb">Pyrogallol-2-O-glucuronide</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/a1f8fd80-2f35-4079-8b0e-aea9ff1c262b">Vanillic
+                        href="http://www.emetabolomics.org/magmaviewer/results/a1f8fd80-2f35-4079-8b0e-aea9ff1c262b">Vanillic
                             acid COOH-glucuronide</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/c0ca88f5-384d-4b44-8c76-d82dabcb53e2">Chlorogenic
+                        href="http://www.emetabolomics.org/magmaviewer/results/c0ca88f5-384d-4b44-8c76-d82dabcb53e2">Chlorogenic
                             acid</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/480815b5-9691-4330-8135-3f0fd668560a">Catechin-O-methyl-O-sulphate*</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/480815b5-9691-4330-8135-3f0fd668560a">Catechin-O-methyl-O-sulphate*</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/a2820437-002c-4b09-981f-9260d5038eb1">3,5-diOH-Valerolactone-3-O-glucuronide</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/a2820437-002c-4b09-981f-9260d5038eb1">3,5-diOH-Valerolactone-3-O-glucuronide</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/5738d0d6-8c42-4c4d-ba4d-0650310b51e9">Vitexin</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/5738d0d6-8c42-4c4d-ba4d-0650310b51e9">Vitexin</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/62d217d3-ac98-4588-a455-c54ee3c8cfc2">Naringenin-7-O-glucoside</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/62d217d3-ac98-4588-a455-c54ee3c8cfc2">Naringenin-7-O-glucoside</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/90577cbd-6616-44fa-a333-2c457e329879">Maritimein</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/90577cbd-6616-44fa-a333-2c457e329879">Maritimein</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/dc8a69dd-fa9f-45f7-b103-6a3c319aeb1f">Eriodictyol-7-O-glucoside</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/dc8a69dd-fa9f-45f7-b103-6a3c319aeb1f">Eriodictyol-7-O-glucoside</a></li>
 
                     <li><a
-                        href="/magmaviewer/results/7675a243-dcae-4555-ad1b-18e43678e6bd">Rutin</a></li>
+                        href="http://www.emetabolomics.org/magmaviewer/results/7675a243-dcae-4555-ad1b-18e43678e6bd">Rutin</a></li>
                 </ul>
                 <p>* Note: the results provided are those obtained with the spectral data up to MS<sup>4</sup>.</p>
             </div>
@@ -99,7 +99,7 @@ body {
                 </ul>
                 </br>
                 <p>When you have selected a candidate molecule the annotated
-                    spectral tree becomes available on the right.</p> 
+                    spectral tree becomes available on the right.</p>
                 </br>
                 <p>Substructures (upper right)</p>
                 <ul>

--- a/emetabolomics_site/robots.txt
+++ b/emetabolomics_site/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /magma/


### PR DESCRIPTION
Then the links will work when visiting http://www.emetabolomics.org or https://www.emetabolomics.org .

Also added robots.txt to prevent robots from indexing /magma/.
Fixes #169
