### PR TITLE
When running 2 MAGMa web instances as http://www.emetabolomics.org/magma...

### DIFF
--- a/web/magmaweb/__init__.py
+++ b/web/magmaweb/__init__.py
@@ -24,6 +24,9 @@ def main(global_config, **settings):
         path=settings['cookie.path'],
         hashalg='sha512',
         callback=groupfinder,
+        cookie_name=settings.get('cookie.name', 'auth_tkt'),
+        wild_domain=False,
+        http_only=True,
     )
 
     # for service consumers

--- a/web/production.ini-dist
+++ b/web/production.ini-dist
@@ -15,6 +15,7 @@ mako.directories = magmaweb:templates
 # secret for cookie signing
 cookie.secret = agh7ahfixeiwieCh6Oovei1faecao4ee
 cookie.path = /magma
+cookie.path = magma
 
 # When auto_register is true then
 # It's not needed to create a user account


### PR DESCRIPTION
... and https://www.emetabolomics.org/magma

authentication uses the same cookie.
So by logging in to the public then you are automaticly logout from the private.

Add cookie name to config so each instance has it's own cookie.
