### PR TITLE
In log there where 'database is locked' errors. These cause state update...

### DIFF
--- a/web/magmaweb/user.py
+++ b/web/magmaweb/user.py
@@ -37,6 +37,7 @@ def init_user_db(engine, create=True, fill=True):
     Set 'create' to False to skip createing tables.
     Set 'fill' to False to skip adding 'joblauncher' user.
     """
+    engine.execute('PRAGMA journal_mode=WAL')
     DBSession.configure(bind=engine)
     Base.metadata.bind = engine
     if create:


### PR DESCRIPTION
...s to fail.

Force user db to Write-Ahead Logging for atomic commits.
See http://www.sqlite.org/wal.html .
This allows reads and writes concurrently.

Fixes #182.
