### PR TITLE
Increase sqlite timeout from default (5s) to 30s.

### DIFF
--- a/web/production.ini-dist
+++ b/web/production.ini-dist
@@ -32,7 +32,7 @@ access_token.expires_in = 30758400
 monitor_user = joblauncher
 
 # user database
-sqlalchemy.url = sqlite:///%(here)s/data/users.db
+sqlalchemy.url = sqlite:///%(here)s/data/users.db?timeout=30
 
 # In magmaweb/static/ which ExtJS directory to use
 extjsroot = extjs-4.2.0


### PR DESCRIPTION
From pysqlite docs:
When a database is accessed by multiple connections, and one of the processes modifies the database, the SQLite database is locked until that transaction is committed. The timeout parameter specifies how long the connection should wait for the lock to go away until raising an exception.

Refs #182.
