### PR TITLE
New WebTest checks cookie paths better.

### DIFF
--- a/web/magmaweb/tests/test_functional.py
+++ b/web/magmaweb/tests/test_functional.py
@@ -20,7 +20,7 @@ class FunctionalTests(unittest.TestCase):
                     'extjsroot': 'ext',
                     'sqlalchemy.url': 'sqlite:///:memory:',
                     'cookie.secret': 'aepeeV6aizaiph5Ae0Reimeequuluwoh',
-                    'cookie.path': '/magma',
+                    'cookie.path': '/',
                     'monitor_user': 'jobmanager',
                     }
         settings.update(self.settings)


### PR DESCRIPTION
Causing tests to fail because auth cookie was not passed when fetching pages.
The cookie.path was changed from '/magma' to '/', this path is also the path the tests use.

Fixes #196.
