### PR TITLE
line.peak style now darker 

### DIFF
--- a/web/magmaweb/static/style.css
+++ b/web/magmaweb/static/style.css
@@ -59,7 +59,7 @@ path.moleculeline {
 
 line.peak {
 	stroke-width: 2px;
-	stroke: #eee;
+	stroke: #bbb;
 }
 
 .marker {


### PR DESCRIPTION
(they were too light to be seen on older screens)

trying to resolve [this](https://github.com/NLeSC/collab-demos/issues/73) issue.
